### PR TITLE
Apryse Component Subclass sample

### DIFF
--- a/ApryseComponentSubclassing/ApryseComponentSubclassing.xcodeproj/project.pbxproj
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		7DFA97A02B3F387A008F4B5D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7DFA979F2B3F387A008F4B5D /* Assets.xcassets */; };
 		7DFA97A32B3F387A008F4B5D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DFA97A12B3F387A008F4B5D /* LaunchScreen.storyboard */; };
 		7DFA97AC2B3F41A1008F4B5D /* PDFTron in Frameworks */ = {isa = PBXBuildFile; productRef = 7DFA97AB2B3F41A1008F4B5D /* PDFTron */; };
+		7DFA97AE2B3F44BD008F4B5D /* MyAnnotStyle.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFA97AD2B3F44BD008F4B5D /* MyAnnotStyle.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -25,6 +26,7 @@
 		7DFA979F2B3F387A008F4B5D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		7DFA97A22B3F387A008F4B5D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
 		7DFA97A42B3F387A008F4B5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+		7DFA97AD2B3F44BD008F4B5D /* MyAnnotStyle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MyAnnotStyle.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -61,6 +63,7 @@
 				7DFA97962B3F3879008F4B5D /* AppDelegate.swift */,
 				7DFA97982B3F3879008F4B5D /* SceneDelegate.swift */,
 				7DFA979A2B3F3879008F4B5D /* ViewController.swift */,
+				7DFA97AD2B3F44BD008F4B5D /* MyAnnotStyle.swift */,
 				7DFA979C2B3F3879008F4B5D /* Main.storyboard */,
 				7DFA979F2B3F387A008F4B5D /* Assets.xcassets */,
 				7DFA97A12B3F387A008F4B5D /* LaunchScreen.storyboard */,
@@ -146,6 +149,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7DFA97AE2B3F44BD008F4B5D /* MyAnnotStyle.swift in Sources */,
 				7DFA979B2B3F3879008F4B5D /* ViewController.swift in Sources */,
 				7DFA97972B3F3879008F4B5D /* AppDelegate.swift in Sources */,
 				7DFA97992B3F3879008F4B5D /* SceneDelegate.swift in Sources */,

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing.xcodeproj/project.pbxproj
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing.xcodeproj/project.pbxproj
@@ -13,6 +13,7 @@
 		7DFA979E2B3F3879008F4B5D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DFA979C2B3F3879008F4B5D /* Main.storyboard */; };
 		7DFA97A02B3F387A008F4B5D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7DFA979F2B3F387A008F4B5D /* Assets.xcassets */; };
 		7DFA97A32B3F387A008F4B5D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DFA97A12B3F387A008F4B5D /* LaunchScreen.storyboard */; };
+		7DFA97AC2B3F41A1008F4B5D /* PDFTron in Frameworks */ = {isa = PBXBuildFile; productRef = 7DFA97AB2B3F41A1008F4B5D /* PDFTron */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -31,6 +32,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				7DFA97AC2B3F41A1008F4B5D /* PDFTron in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -83,6 +85,9 @@
 			dependencies = (
 			);
 			name = ApryseComponentSubclassing;
+			packageProductDependencies = (
+				7DFA97AB2B3F41A1008F4B5D /* PDFTron */,
+			);
 			productName = ApryseComponentSubclassing;
 			productReference = 7DFA97932B3F3879008F4B5D /* ApryseComponentSubclassing.app */;
 			productType = "com.apple.product-type.application";
@@ -111,6 +116,9 @@
 				Base,
 			);
 			mainGroup = 7DFA978A2B3F3879008F4B5D;
+			packageReferences = (
+				7DFA97AA2B3F41A1008F4B5D /* XCRemoteSwiftPackageReference "pdftron-apple-package" */,
+			);
 			productRefGroup = 7DFA97942B3F3879008F4B5D /* Products */;
 			projectDirPath = "";
 			projectRoot = "";
@@ -361,6 +369,25 @@
 			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
+
+/* Begin XCRemoteSwiftPackageReference section */
+		7DFA97AA2B3F41A1008F4B5D /* XCRemoteSwiftPackageReference "pdftron-apple-package" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/PDFTron/pdftron-apple-package";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 10.6.83126;
+			};
+		};
+/* End XCRemoteSwiftPackageReference section */
+
+/* Begin XCSwiftPackageProductDependency section */
+		7DFA97AB2B3F41A1008F4B5D /* PDFTron */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 7DFA97AA2B3F41A1008F4B5D /* XCRemoteSwiftPackageReference "pdftron-apple-package" */;
+			productName = PDFTron;
+		};
+/* End XCSwiftPackageProductDependency section */
 	};
 	rootObject = 7DFA978B2B3F3879008F4B5D /* Project object */;
 }

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing.xcodeproj/project.pbxproj
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing.xcodeproj/project.pbxproj
@@ -1,0 +1,366 @@
+// !$*UTF8*$!
+{
+	archiveVersion = 1;
+	classes = {
+	};
+	objectVersion = 56;
+	objects = {
+
+/* Begin PBXBuildFile section */
+		7DFA97972B3F3879008F4B5D /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFA97962B3F3879008F4B5D /* AppDelegate.swift */; };
+		7DFA97992B3F3879008F4B5D /* SceneDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFA97982B3F3879008F4B5D /* SceneDelegate.swift */; };
+		7DFA979B2B3F3879008F4B5D /* ViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7DFA979A2B3F3879008F4B5D /* ViewController.swift */; };
+		7DFA979E2B3F3879008F4B5D /* Main.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DFA979C2B3F3879008F4B5D /* Main.storyboard */; };
+		7DFA97A02B3F387A008F4B5D /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 7DFA979F2B3F387A008F4B5D /* Assets.xcassets */; };
+		7DFA97A32B3F387A008F4B5D /* LaunchScreen.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = 7DFA97A12B3F387A008F4B5D /* LaunchScreen.storyboard */; };
+/* End PBXBuildFile section */
+
+/* Begin PBXFileReference section */
+		7DFA97932B3F3879008F4B5D /* ApryseComponentSubclassing.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ApryseComponentSubclassing.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		7DFA97962B3F3879008F4B5D /* AppDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppDelegate.swift; sourceTree = "<group>"; };
+		7DFA97982B3F3879008F4B5D /* SceneDelegate.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SceneDelegate.swift; sourceTree = "<group>"; };
+		7DFA979A2B3F3879008F4B5D /* ViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ViewController.swift; sourceTree = "<group>"; };
+		7DFA979D2B3F3879008F4B5D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/Main.storyboard; sourceTree = "<group>"; };
+		7DFA979F2B3F387A008F4B5D /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
+		7DFA97A22B3F387A008F4B5D /* Base */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; name = Base; path = Base.lproj/LaunchScreen.storyboard; sourceTree = "<group>"; };
+		7DFA97A42B3F387A008F4B5D /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
+/* End PBXFileReference section */
+
+/* Begin PBXFrameworksBuildPhase section */
+		7DFA97902B3F3879008F4B5D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXFrameworksBuildPhase section */
+
+/* Begin PBXGroup section */
+		7DFA978A2B3F3879008F4B5D = {
+			isa = PBXGroup;
+			children = (
+				7DFA97952B3F3879008F4B5D /* ApryseComponentSubclassing */,
+				7DFA97942B3F3879008F4B5D /* Products */,
+			);
+			sourceTree = "<group>";
+		};
+		7DFA97942B3F3879008F4B5D /* Products */ = {
+			isa = PBXGroup;
+			children = (
+				7DFA97932B3F3879008F4B5D /* ApryseComponentSubclassing.app */,
+			);
+			name = Products;
+			sourceTree = "<group>";
+		};
+		7DFA97952B3F3879008F4B5D /* ApryseComponentSubclassing */ = {
+			isa = PBXGroup;
+			children = (
+				7DFA97962B3F3879008F4B5D /* AppDelegate.swift */,
+				7DFA97982B3F3879008F4B5D /* SceneDelegate.swift */,
+				7DFA979A2B3F3879008F4B5D /* ViewController.swift */,
+				7DFA979C2B3F3879008F4B5D /* Main.storyboard */,
+				7DFA979F2B3F387A008F4B5D /* Assets.xcassets */,
+				7DFA97A12B3F387A008F4B5D /* LaunchScreen.storyboard */,
+				7DFA97A42B3F387A008F4B5D /* Info.plist */,
+			);
+			path = ApryseComponentSubclassing;
+			sourceTree = "<group>";
+		};
+/* End PBXGroup section */
+
+/* Begin PBXNativeTarget section */
+		7DFA97922B3F3879008F4B5D /* ApryseComponentSubclassing */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 7DFA97A72B3F387A008F4B5D /* Build configuration list for PBXNativeTarget "ApryseComponentSubclassing" */;
+			buildPhases = (
+				7DFA978F2B3F3879008F4B5D /* Sources */,
+				7DFA97902B3F3879008F4B5D /* Frameworks */,
+				7DFA97912B3F3879008F4B5D /* Resources */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = ApryseComponentSubclassing;
+			productName = ApryseComponentSubclassing;
+			productReference = 7DFA97932B3F3879008F4B5D /* ApryseComponentSubclassing.app */;
+			productType = "com.apple.product-type.application";
+		};
+/* End PBXNativeTarget section */
+
+/* Begin PBXProject section */
+		7DFA978B2B3F3879008F4B5D /* Project object */ = {
+			isa = PBXProject;
+			attributes = {
+				BuildIndependentTargetsInParallel = 1;
+				LastSwiftUpdateCheck = 1500;
+				LastUpgradeCheck = 1500;
+				TargetAttributes = {
+					7DFA97922B3F3879008F4B5D = {
+						CreatedOnToolsVersion = 15.0.1;
+					};
+				};
+			};
+			buildConfigurationList = 7DFA978E2B3F3879008F4B5D /* Build configuration list for PBXProject "ApryseComponentSubclassing" */;
+			compatibilityVersion = "Xcode 14.0";
+			developmentRegion = en;
+			hasScannedForEncodings = 0;
+			knownRegions = (
+				en,
+				Base,
+			);
+			mainGroup = 7DFA978A2B3F3879008F4B5D;
+			productRefGroup = 7DFA97942B3F3879008F4B5D /* Products */;
+			projectDirPath = "";
+			projectRoot = "";
+			targets = (
+				7DFA97922B3F3879008F4B5D /* ApryseComponentSubclassing */,
+			);
+		};
+/* End PBXProject section */
+
+/* Begin PBXResourcesBuildPhase section */
+		7DFA97912B3F3879008F4B5D /* Resources */ = {
+			isa = PBXResourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7DFA97A32B3F387A008F4B5D /* LaunchScreen.storyboard in Resources */,
+				7DFA97A02B3F387A008F4B5D /* Assets.xcassets in Resources */,
+				7DFA979E2B3F3879008F4B5D /* Main.storyboard in Resources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXResourcesBuildPhase section */
+
+/* Begin PBXSourcesBuildPhase section */
+		7DFA978F2B3F3879008F4B5D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				7DFA979B2B3F3879008F4B5D /* ViewController.swift in Sources */,
+				7DFA97972B3F3879008F4B5D /* AppDelegate.swift in Sources */,
+				7DFA97992B3F3879008F4B5D /* SceneDelegate.swift in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+/* End PBXSourcesBuildPhase section */
+
+/* Begin PBXVariantGroup section */
+		7DFA979C2B3F3879008F4B5D /* Main.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				7DFA979D2B3F3879008F4B5D /* Base */,
+			);
+			name = Main.storyboard;
+			sourceTree = "<group>";
+		};
+		7DFA97A12B3F387A008F4B5D /* LaunchScreen.storyboard */ = {
+			isa = PBXVariantGroup;
+			children = (
+				7DFA97A22B3F387A008F4B5D /* Base */,
+			);
+			name = LaunchScreen.storyboard;
+			sourceTree = "<group>";
+		};
+/* End PBXVariantGroup section */
+
+/* Begin XCBuildConfiguration section */
+		7DFA97A52B3F387A008F4B5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = dwarf;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_DYNAMIC_NO_PIC = NO;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_OPTIMIZATION_LEVEL = 0;
+				GCC_PREPROCESSOR_DEFINITIONS = (
+					"DEBUG=1",
+					"$(inherited)",
+				);
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
+				MTL_FAST_MATH = YES;
+				ONLY_ACTIVE_ARCH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_ACTIVE_COMPILATION_CONDITIONS = "DEBUG $(inherited)";
+				SWIFT_OPTIMIZATION_LEVEL = "-Onone";
+			};
+			name = Debug;
+		};
+		7DFA97A62B3F387A008F4B5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ALWAYS_SEARCH_USER_PATHS = NO;
+				ASSETCATALOG_COMPILER_GENERATE_SWIFT_ASSET_SYMBOL_EXTENSIONS = YES;
+				CLANG_ANALYZER_NONNULL = YES;
+				CLANG_ANALYZER_NUMBER_OBJECT_CONVERSION = YES_AGGRESSIVE;
+				CLANG_CXX_LANGUAGE_STANDARD = "gnu++20";
+				CLANG_ENABLE_MODULES = YES;
+				CLANG_ENABLE_OBJC_ARC = YES;
+				CLANG_ENABLE_OBJC_WEAK = YES;
+				CLANG_WARN_BLOCK_CAPTURE_AUTORELEASING = YES;
+				CLANG_WARN_BOOL_CONVERSION = YES;
+				CLANG_WARN_COMMA = YES;
+				CLANG_WARN_CONSTANT_CONVERSION = YES;
+				CLANG_WARN_DEPRECATED_OBJC_IMPLEMENTATIONS = YES;
+				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
+				CLANG_WARN_DOCUMENTATION_COMMENTS = YES;
+				CLANG_WARN_EMPTY_BODY = YES;
+				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
+				CLANG_WARN_INT_CONVERSION = YES;
+				CLANG_WARN_NON_LITERAL_NULL_CONVERSION = YES;
+				CLANG_WARN_OBJC_IMPLICIT_RETAIN_SELF = YES;
+				CLANG_WARN_OBJC_LITERAL_CONVERSION = YES;
+				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_QUOTED_INCLUDE_IN_FRAMEWORK_HEADER = YES;
+				CLANG_WARN_RANGE_LOOP_ANALYSIS = YES;
+				CLANG_WARN_STRICT_PROTOTYPES = YES;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
+				CLANG_WARN_UNGUARDED_AVAILABILITY = YES_AGGRESSIVE;
+				CLANG_WARN_UNREACHABLE_CODE = YES;
+				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
+				COPY_PHASE_STRIP = NO;
+				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
+				ENABLE_NS_ASSERTIONS = NO;
+				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_USER_SCRIPT_SANDBOXING = YES;
+				GCC_C_LANGUAGE_STANDARD = gnu17;
+				GCC_NO_COMMON_BLOCKS = YES;
+				GCC_WARN_64_TO_32_BIT_CONVERSION = YES;
+				GCC_WARN_ABOUT_RETURN_TYPE = YES_ERROR;
+				GCC_WARN_UNDECLARED_SELECTOR = YES;
+				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
+				GCC_WARN_UNUSED_FUNCTION = YES;
+				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 17.0;
+				LOCALIZATION_PREFERS_STRING_CATALOGS = YES;
+				MTL_ENABLE_DEBUG_INFO = NO;
+				MTL_FAST_MATH = YES;
+				SDKROOT = iphoneos;
+				SWIFT_COMPILATION_MODE = wholemodule;
+				VALIDATE_PRODUCT = YES;
+			};
+			name = Release;
+		};
+		7DFA97A82B3F387A008F4B5D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ApryseComponentSubclassing/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Apryse.sample.ApryseComponentSubclassing;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Debug;
+		};
+		7DFA97A92B3F387A008F4B5D /* Release */ = {
+			isa = XCBuildConfiguration;
+			buildSettings = {
+				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
+				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
+				CODE_SIGN_STYLE = Automatic;
+				CURRENT_PROJECT_VERSION = 1;
+				GENERATE_INFOPLIST_FILE = YES;
+				INFOPLIST_FILE = ApryseComponentSubclassing/Info.plist;
+				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
+				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
+				INFOPLIST_KEY_UIMainStoryboardFile = Main;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPhone = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				LD_RUNPATH_SEARCH_PATHS = (
+					"$(inherited)",
+					"@executable_path/Frameworks",
+				);
+				MARKETING_VERSION = 1.0;
+				PRODUCT_BUNDLE_IDENTIFIER = com.Apryse.sample.ApryseComponentSubclassing;
+				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_EMIT_LOC_STRINGS = YES;
+				SWIFT_VERSION = 5.0;
+				TARGETED_DEVICE_FAMILY = "1,2";
+			};
+			name = Release;
+		};
+/* End XCBuildConfiguration section */
+
+/* Begin XCConfigurationList section */
+		7DFA978E2B3F3879008F4B5D /* Build configuration list for PBXProject "ApryseComponentSubclassing" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7DFA97A52B3F387A008F4B5D /* Debug */,
+				7DFA97A62B3F387A008F4B5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		7DFA97A72B3F387A008F4B5D /* Build configuration list for PBXNativeTarget "ApryseComponentSubclassing" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				7DFA97A82B3F387A008F4B5D /* Debug */,
+				7DFA97A92B3F387A008F4B5D /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+/* End XCConfigurationList section */
+	};
+	rootObject = 7DFA978B2B3F3879008F4B5D /* Project object */;
+}

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing.xcodeproj/project.xcworkspace/contents.xcworkspacedata
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing.xcodeproj/project.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing.xcodeproj/project.xcworkspace/xcshareddata/IDEWorkspaceChecks.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>IDEDidComputeMac32BitWarning</key>
+	<true/>
+</dict>
+</plist>

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing/AppDelegate.swift
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing/AppDelegate.swift
@@ -1,0 +1,34 @@
+//---------------------------------------------------------------------------------------
+// Copyright (c) 2001-2022 by PDFTron Systems Inc. All Rights Reserved.
+// Consult legal.txt regarding legal and license information.
+//---------------------------------------------------------------------------------------
+
+import UIKit
+
+@main
+class AppDelegate: UIResponder, UIApplicationDelegate {
+
+
+
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
+        // Override point for customization after application launch.
+        return true
+    }
+
+    // MARK: UISceneSession Lifecycle
+
+    func application(_ application: UIApplication, configurationForConnecting connectingSceneSession: UISceneSession, options: UIScene.ConnectionOptions) -> UISceneConfiguration {
+        // Called when a new scene session is being created.
+        // Use this method to select a configuration to create the new scene with.
+        return UISceneConfiguration(name: "Default Configuration", sessionRole: connectingSceneSession.role)
+    }
+
+    func application(_ application: UIApplication, didDiscardSceneSessions sceneSessions: Set<UISceneSession>) {
+        // Called when the user discards a scene session.
+        // If any sessions were discarded while the application was not running, this will be called shortly after application:didFinishLaunchingWithOptions.
+        // Use this method to release any resources that were specific to the discarded scenes, as they will not return.
+    }
+
+
+}
+

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing/Assets.xcassets/AccentColor.colorset/Contents.json
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing/Assets.xcassets/AccentColor.colorset/Contents.json
@@ -1,0 +1,11 @@
+{
+  "colors" : [
+    {
+      "idiom" : "universal"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -1,0 +1,13 @@
+{
+  "images" : [
+    {
+      "idiom" : "universal",
+      "platform" : "ios",
+      "size" : "1024x1024"
+    }
+  ],
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing/Assets.xcassets/Contents.json
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing/Assets.xcassets/Contents.json
@@ -1,0 +1,6 @@
+{
+  "info" : {
+    "author" : "xcode",
+    "version" : 1
+  }
+}

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing/Base.lproj/LaunchScreen.storyboard
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing/Base.lproj/LaunchScreen.storyboard
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" launchScreen="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="01J-lp-oVM">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="EHf-IW-A2E">
+            <objects>
+                <viewController id="01J-lp-oVM" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="Ze5-6b-2t3">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="iYj-Kq-Ea1" userLabel="First Responder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="53" y="375"/>
+        </scene>
+    </scenes>
+</document>

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing/Base.lproj/Main.storyboard
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing/Base.lproj/Main.storyboard
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<document type="com.apple.InterfaceBuilder3.CocoaTouch.Storyboard.XIB" version="3.0" toolsVersion="13122.16" targetRuntime="iOS.CocoaTouch" propertyAccessControl="none" useAutolayout="YES" useTraitCollections="YES" useSafeAreas="YES" colorMatched="YES" initialViewController="BYZ-38-t0r">
+    <dependencies>
+        <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="13104.12"/>
+        <capability name="Safe area layout guides" minToolsVersion="9.0"/>
+        <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
+    </dependencies>
+    <scenes>
+        <!--View Controller-->
+        <scene sceneID="tne-QT-ifu">
+            <objects>
+                <viewController id="BYZ-38-t0r" customClass="ViewController" customModuleProvider="target" sceneMemberID="viewController">
+                    <view key="view" contentMode="scaleToFill" id="8bC-Xf-vdC">
+                        <rect key="frame" x="0.0" y="0.0" width="375" height="667"/>
+                        <autoresizingMask key="autoresizingMask" widthSizable="YES" heightSizable="YES"/>
+                        <color key="backgroundColor" xcode11CocoaTouchSystemColor="systemBackgroundColor" cocoaTouchSystemColor="whiteColor"/>
+                        <viewLayoutGuide key="safeArea" id="6Tk-OE-BBY"/>
+                    </view>
+                </viewController>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="dkx-z0-nzr" sceneMemberID="firstResponder"/>
+            </objects>
+        </scene>
+    </scenes>
+</document>

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing/Info.plist
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing/Info.plist
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>UIApplicationSceneManifest</key>
+	<dict>
+		<key>UIApplicationSupportsMultipleScenes</key>
+		<false/>
+		<key>UISceneConfigurations</key>
+		<dict>
+			<key>UIWindowSceneSessionRoleApplication</key>
+			<array>
+				<dict>
+					<key>UISceneConfigurationName</key>
+					<string>Default Configuration</string>
+					<key>UISceneDelegateClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SceneDelegate</string>
+					<key>UISceneStoryboardFile</key>
+					<string>Main</string>
+				</dict>
+			</array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing/MyAnnotStyle.swift
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing/MyAnnotStyle.swift
@@ -1,0 +1,25 @@
+//---------------------------------------------------------------------------------------
+// Copyright (c) 2001-2022 by PDFTron Systems Inc. All Rights Reserved.
+// Consult legal.txt regarding legal and license information.
+//---------------------------------------------------------------------------------------
+
+import UIKit
+import Tools
+
+class MyAnnotStyle: PTAnnotStyle {
+
+    // Override the available style keys to remove the fillColor setting for square-type annotations
+    override var availableStyleKeys: [PTAnnotStyleKey] {
+        // Get the default style keys
+        var styleKeys = super.availableStyleKeys
+
+        // If the `annotType` is a square then remove the `fillColor` option
+        if self.annotType == .square {
+            styleKeys.removeAll { key in
+                key == PTAnnotStyleKey.fillColor
+            }
+        }
+
+        return styleKeys
+    }
+}

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing/SceneDelegate.swift
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing/SceneDelegate.swift
@@ -1,0 +1,50 @@
+//---------------------------------------------------------------------------------------
+// Copyright (c) 2001-2022 by PDFTron Systems Inc. All Rights Reserved.
+// Consult legal.txt regarding legal and license information.
+//---------------------------------------------------------------------------------------
+
+import UIKit
+
+class SceneDelegate: UIResponder, UIWindowSceneDelegate {
+
+    var window: UIWindow?
+
+
+    func scene(_ scene: UIScene, willConnectTo session: UISceneSession, options connectionOptions: UIScene.ConnectionOptions) {
+        // Use this method to optionally configure and attach the UIWindow `window` to the provided UIWindowScene `scene`.
+        // If using a storyboard, the `window` property will automatically be initialized and attached to the scene.
+        // This delegate does not imply the connecting scene or session are new (see `application:configurationForConnectingSceneSession` instead).
+        guard let _ = (scene as? UIWindowScene) else { return }
+    }
+
+    func sceneDidDisconnect(_ scene: UIScene) {
+        // Called as the scene is being released by the system.
+        // This occurs shortly after the scene enters the background, or when its session is discarded.
+        // Release any resources associated with this scene that can be re-created the next time the scene connects.
+        // The scene may re-connect later, as its session was not necessarily discarded (see `application:didDiscardSceneSessions` instead).
+    }
+
+    func sceneDidBecomeActive(_ scene: UIScene) {
+        // Called when the scene has moved from an inactive state to an active state.
+        // Use this method to restart any tasks that were paused (or not yet started) when the scene was inactive.
+    }
+
+    func sceneWillResignActive(_ scene: UIScene) {
+        // Called when the scene will move from an active state to an inactive state.
+        // This may occur due to temporary interruptions (ex. an incoming phone call).
+    }
+
+    func sceneWillEnterForeground(_ scene: UIScene) {
+        // Called as the scene transitions from the background to the foreground.
+        // Use this method to undo the changes made on entering the background.
+    }
+
+    func sceneDidEnterBackground(_ scene: UIScene) {
+        // Called as the scene transitions from the foreground to the background.
+        // Use this method to save data, release shared resources, and store enough scene-specific state information
+        // to restore the scene back to its current state.
+    }
+
+
+}
+

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing/ViewController.swift
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing/ViewController.swift
@@ -1,0 +1,17 @@
+//---------------------------------------------------------------------------------------
+// Copyright (c) 2001-2022 by PDFTron Systems Inc. All Rights Reserved.
+// Consult legal.txt regarding legal and license information.
+//---------------------------------------------------------------------------------------
+
+import UIKit
+
+class ViewController: UIViewController {
+
+    override func viewDidLoad() {
+        super.viewDidLoad()
+        // Do any additional setup after loading the view.
+    }
+
+
+}
+

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing/ViewController.swift
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing/ViewController.swift
@@ -4,6 +4,7 @@
 //---------------------------------------------------------------------------------------
 
 import UIKit
+import Tools
 
 class ViewController: UIViewController {
 
@@ -11,7 +12,20 @@ class ViewController: UIViewController {
         super.viewDidLoad()
         // Do any additional setup after loading the view.
     }
-
-
+    
+    override func viewDidAppear(_ animated: Bool) {
+        // Create a PTDocumentController
+        let documentController = PTDocumentController()
+        // The PTDocumentController must be in a navigation controller before a document can be opened
+        let navigationController = UINavigationController(rootViewController: documentController)
+        navigationController.modalPresentationStyle = .fullScreen
+        navigationController.navigationBar.isTranslucent = false
+        navigationController.toolbar.isTranslucent = false
+        // Open a file from URL.
+        let fileURL: URL = URL(string:"https://pdftron.s3.amazonaws.com/downloads/pl/sample.pdf")!
+        documentController.openDocument(with: fileURL)
+        // Show navigation (and document) controller.
+        self.present(navigationController, animated: true, completion: nil)
+    }
 }
 

--- a/ApryseComponentSubclassing/ApryseComponentSubclassing/ViewController.swift
+++ b/ApryseComponentSubclassing/ApryseComponentSubclassing/ViewController.swift
@@ -10,7 +10,9 @@ class ViewController: UIViewController {
 
     override func viewDidLoad() {
         super.viewDidLoad()
-        // Do any additional setup after loading the view.
+
+        // Use the `PTOverrides` system to register your subclass. This should be done before any Apryse classes are invoked.
+        PTOverrides.addOverriddenClass(MyAnnotStyle.self)
     }
     
     override func viewDidAppear(_ animated: Bool) {


### PR DESCRIPTION
This sample demonstrates how to subclass an Apryse SDK component, in this case the `PTAnnotStyle`
https://docs.apryse.com/api/ios/Classes/PTAnnotStyle.html

The sample shows how to override this class to control which style options can be set for a certain annotation type.